### PR TITLE
Enabled user to type only task name or only task url

### DIFF
--- a/TimeTable/Categories/WorkTime/WorkTimeViewModel.swift
+++ b/TimeTable/Categories/WorkTime/WorkTimeViewModel.swift
@@ -169,10 +169,7 @@ class WorkTimeViewModel: WorkTimeViewModelType {
     // MARK: - Private
     private func validateInputs() throws {
         guard .none != task.project else { throw UIError.cannotBeEmpty(.projectTextField) }
-        guard !task.body.isEmpty else { throw UIError.cannotBeEmpty(.taskTextField) }
-        if task.allowsTask && task.url == nil {
-            throw UIError.cannotBeEmpty(.taskURLTextField)
-        }
+        guard !task.body.isEmpty || (task.allowsTask && task.url != nil) else { throw UIError.cannotBeEmpty(.taskTextField) }
         guard let fromDate = task.startAt else { throw UIError.cannotBeEmpty(.startsAtTextField) }
         guard let toDate = task.endAt else { throw UIError.cannotBeEmpty(.endsAtTextField) }
         guard fromDate < toDate else { throw UIError.timeGreaterThan }

--- a/TimeTableTests/Categories/WorkTime/WorkTimeViewModelTests.swift
+++ b/TimeTableTests/Categories/WorkTime/WorkTimeViewModelTests.swift
@@ -222,11 +222,7 @@ class WorkTimeViewModelTests: XCTestCase {
         viewModel.taskURLDidChange(value: nil)
         viewModel.viewRequestedToSave()
         //Assert
-        switch errorHandlerMock.throwedError as? UIError {
-        case .cannotBeEmpty(let element)?:
-            XCTAssertEqual(element, UIElement.taskURLTextField)
-        default: XCTFail()
-        }
+        XCTAssertEqual(errorHandlerMock.throwedError as? UIError, nil)
     }
     
     func testViewRequestedToSaveWhileTaskURLWasSetAsInvalidURL() throws {
@@ -238,11 +234,7 @@ class WorkTimeViewModelTests: XCTestCase {
         viewModel.taskURLDidChange(value: "\\INVALID//")
         viewModel.viewRequestedToSave()
         //Assert
-        switch errorHandlerMock.throwedError as? UIError {
-        case .cannotBeEmpty(let element)?:
-            XCTAssertEqual(element, UIElement.taskURLTextField)
-        default: XCTFail()
-        }
+        XCTAssertEqual(errorHandlerMock.throwedError as? UIError, nil)
     }
     
     func testViewRequestedToSaveWhileTaskURLIsNil() throws {
@@ -253,11 +245,7 @@ class WorkTimeViewModelTests: XCTestCase {
         //Act
         viewModel.viewRequestedToSave()
         //Assert
-        switch errorHandlerMock.throwedError as? UIError {
-        case .cannotBeEmpty(let element)?:
-            XCTAssertEqual(element, UIElement.taskURLTextField)
-        default: XCTFail()
-        }
+        XCTAssertEqual(errorHandlerMock.throwedError as? UIError, nil)
     }
     
     func testViewRequestedToSaveWhileTaskFromDateIsNil() throws {

--- a/TimeTableTests/Categories/WorkTime/WorkTimeViewModelTests.swift
+++ b/TimeTableTests/Categories/WorkTime/WorkTimeViewModelTests.swift
@@ -213,6 +213,18 @@ class WorkTimeViewModelTests: XCTestCase {
         }
     }
     
+    func testViewRequestedToSaveWhileTaskBodyIsNilAndURLIsNot() throws {
+        //Arrange
+        try fetchProjects()
+        viewModel.viewSelectedProject(atRow: 1)
+        viewModel.taskNameDidChange(value: nil)
+        //Act
+        viewModel.taskURLDidChange(value: "www.example.com")
+        viewModel.viewRequestedToSave()
+        //Assert
+        XCTAssertNil(errorHandlerMock.throwedError as? UIError)
+    }
+    
     func testViewRequestedToSaveWhileTaskURLWasSetAsNil() throws {
         //Arrange
         try fetchProjects()
@@ -222,7 +234,7 @@ class WorkTimeViewModelTests: XCTestCase {
         viewModel.taskURLDidChange(value: nil)
         viewModel.viewRequestedToSave()
         //Assert
-        XCTAssertEqual(errorHandlerMock.throwedError as? UIError, nil)
+        XCTAssertNil(errorHandlerMock.throwedError as? UIError)
     }
     
     func testViewRequestedToSaveWhileTaskURLWasSetAsInvalidURL() throws {
@@ -234,7 +246,7 @@ class WorkTimeViewModelTests: XCTestCase {
         viewModel.taskURLDidChange(value: "\\INVALID//")
         viewModel.viewRequestedToSave()
         //Assert
-        XCTAssertEqual(errorHandlerMock.throwedError as? UIError, nil)
+        XCTAssertNil(errorHandlerMock.throwedError as? UIError)
     }
     
     func testViewRequestedToSaveWhileTaskURLIsNil() throws {
@@ -245,7 +257,7 @@ class WorkTimeViewModelTests: XCTestCase {
         //Act
         viewModel.viewRequestedToSave()
         //Assert
-        XCTAssertEqual(errorHandlerMock.throwedError as? UIError, nil)
+        XCTAssertNil(errorHandlerMock.throwedError as? UIError)
     }
     
     func testViewRequestedToSaveWhileTaskFromDateIsNil() throws {


### PR DESCRIPTION
I changed a little tests to don't throw exception, when url is nil but task name is not empty. Also I've added one test for new case