### PR TITLE
Set start time of new task to last task end time

### DIFF
--- a/TimeTable.xcodeproj/project.pbxproj
+++ b/TimeTable.xcodeproj/project.pbxproj
@@ -1691,7 +1691,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1000;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = Railwaymen;
 				TargetAttributes = {
 					C1B5136821772D1200C3727C = {

--- a/TimeTable.xcodeproj/xcshareddata/xcschemes/TimeTable.xcscheme
+++ b/TimeTable.xcodeproj/xcshareddata/xcschemes/TimeTable.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TimeTable/Categories/WorkTime/WorkTimeController.swift
+++ b/TimeTable/Categories/WorkTime/WorkTimeController.swift
@@ -175,22 +175,22 @@ extension WorkTimeController: WorkTimeViewModelOutput {
     }
     
     func setMinimumDateForTypeEndAtDate(minDate: Date) {
-        endAtDatePicker.minimumDate = minDate
+        endAtDatePicker?.minimumDate = minDate
     }
     
     func updateDay(with date: Date, dateString: String) {
         dayTextField.text = dateString
-        startAtDatePicker.date = date
+        startAtDatePicker?.date = date
     }
     
     func updateStartAtDate(with date: Date, dateString: String) {
         startAtDateTextField.text = dateString
-        startAtDatePicker.date = date
+        startAtDatePicker?.date = date
     }
     
     func updateEndAtDate(with date: Date, dateString: String) {
         endAtDateTextField.text = dateString
-        endAtDatePicker.date = date
+        endAtDatePicker?.date = date
     }
 }
 

--- a/TimeTable/Categories/WorkTime/WorkTimeViewModel.swift
+++ b/TimeTable/Categories/WorkTime/WorkTimeViewModel.swift
@@ -175,27 +175,29 @@ class WorkTimeViewModel: WorkTimeViewModelType {
         userInterface?.setUp(currentProjectName: task.title, allowsTask: task.allowsTask)
         
         guard let type = task.type else { return }
+        let fromDate: Date
+        let toDate: Date
         switch type {
         case .fullDay(let timeInterval):
-            let fromDate = calendar.date(bySettingHour: 9, minute: 0, second: 0, of: Date()) ?? Date()
-            let toDate = fromDate.addingTimeInterval(timeInterval)
+            fromDate = calendar.date(bySettingHour: 9, minute: 0, second: 0, of: Date()) ?? Date()
+            toDate = fromDate.addingTimeInterval(timeInterval)
             task.startAt = fromDate
             task.endAt = toDate
-            updateStartAtDateView(with: fromDate)
-            updateEndAtDateView(with: toDate)
         case .lunch(let timeInterval):
-            let fromDate = task.startAt ?? Date()
-            let toDate = fromDate.addingTimeInterval(timeInterval)
+            fromDate = task.startAt ?? Date()
+            toDate = fromDate.addingTimeInterval(timeInterval)
             task.startAt = fromDate
             task.endAt = toDate
-            updateStartAtDateView(with: fromDate)
-            updateEndAtDateView(with: toDate)
         case .standard:
-            task.startAt = lastTask?.endAt ?? Date()
-            task.endAt = task.startAt
+            fromDate = lastTask?.endAt ?? Date()
+            toDate = fromDate
+            task.startAt = fromDate
+            task.endAt = toDate
             setDefaultStartAtDate()
             setDefaultEndAtDate()
         }
+        updateStartAtDateView(with: fromDate)
+        updateEndAtDateView(with: toDate)
     }
     
     private func updateDayView(with date: Date) {

--- a/TimeTable/Categories/WorkTime/WorkTimeViewModel.swift
+++ b/TimeTable/Categories/WorkTime/WorkTimeViewModel.swift
@@ -54,9 +54,13 @@ class WorkTimeViewModel: WorkTimeViewModelType {
         self.apiClient = apiClient
         self.errorHandler = errorHandler
         self.calendar = calendar
-        self.lastTask = lastTask
+        if let lastTaskEndAt = lastTask?.endAt, Calendar.current.isDateInToday(lastTaskEndAt) {
+            self.lastTask = lastTask
+        } else {
+            self.lastTask = nil
+        }
         self.projects = []
-        self.task = Task(project: .none, body: "", url: nil, day: Date(), startAt: lastTask?.endAt, endAt: nil)
+        self.task = Task(project: .none, body: "", url: nil, day: Date(), startAt: self.lastTask?.endAt, endAt: nil)
     }
     
     // MARK: - WorkTimeViewModelType

--- a/TimeTable/Categories/WorkTime/WorkTimeViewModel.swift
+++ b/TimeTable/Categories/WorkTime/WorkTimeViewModel.swift
@@ -43,18 +43,20 @@ class WorkTimeViewModel: WorkTimeViewModelType {
     private let apiClient: TimeTableTabApiClientType
     private let errorHandler: ErrorHandlerType
     private let calendar: CalendarType
+    private let lastTask: Task?
     private var projects: [ProjectDecoder]
     private var task: Task
     
     // MARK: - Initialization
-    
-    init(userInterface: WorkTimeViewModelOutput?, apiClient: TimeTableTabApiClientType, errorHandler: ErrorHandlerType, calendar: CalendarType) {
+    init(userInterface: WorkTimeViewModelOutput?, apiClient: TimeTableTabApiClientType, errorHandler: ErrorHandlerType, calendar: CalendarType,
+         lastTask: Task?) {
         self.userInterface = userInterface
         self.apiClient = apiClient
         self.errorHandler = errorHandler
         self.calendar = calendar
+        self.lastTask = lastTask
         self.projects = []
-        self.task = Task(project: .none, body: "", url: nil, day: Date(), startAt: nil, endAt: nil)
+        self.task = Task(project: .none, body: "", url: nil, day: Date(), startAt: lastTask?.endAt, endAt: nil)
     }
     
     // MARK: - WorkTimeViewModelType
@@ -103,10 +105,7 @@ class WorkTimeViewModel: WorkTimeViewModelType {
     }
     
     func setDefaultDay() {
-        var date = Date()
-        if let day = task.day {
-            date = day
-        }
+        let date = task.day ?? Date()
         task.day = date
         updateDayView(with: date)
     }
@@ -122,10 +121,7 @@ class WorkTimeViewModel: WorkTimeViewModelType {
     }
     
     func setDefaultStartAtDate() {
-        var date = Date()
-        if let startAt = task.startAt {
-            date = startAt
-        }
+        let date = task.startAt ?? Date()
         task.startAt = date
         updateStartAtDateView(with: date)
     }
@@ -136,7 +132,7 @@ class WorkTimeViewModel: WorkTimeViewModelType {
     }
     
     func setDefaultEndAtDate() {
-        var date =  Date()
+        var date = Date()
         if let toDate = task.endAt {
             date = toDate
         } else {
@@ -188,13 +184,17 @@ class WorkTimeViewModel: WorkTimeViewModelType {
             updateStartAtDateView(with: fromDate)
             updateEndAtDateView(with: toDate)
         case .lunch(let timeInterval):
-            let fromDate = task.startAt ?? calendar.date(bySettingHour: 9, minute: 0, second: 0, of: Date()) ?? Date()
+            let fromDate = task.startAt ?? Date()
             let toDate = fromDate.addingTimeInterval(timeInterval)
             task.startAt = fromDate
             task.endAt = toDate
             updateStartAtDateView(with: fromDate)
             updateEndAtDateView(with: toDate)
-        case .standard: break
+        case .standard:
+            task.startAt = lastTask?.endAt ?? Date()
+            task.endAt = task.startAt
+            setDefaultStartAtDate()
+            setDefaultEndAtDate()
         }
     }
     

--- a/TimeTable/Categories/WorkTimes/WorkTimesViewModel.swift
+++ b/TimeTable/Categories/WorkTimes/WorkTimesViewModel.swift
@@ -113,7 +113,16 @@ class WorkTimesViewModel: WorkTimesViewModelType {
     }
     
     func viewRequestedForNewWorkTimeView(sourceView: UIButton) {
-        coordinator.workTimesRequestedForNewWorkTimeView(sourceView: sourceView)
+        let lastWorkTime = dailyWorkTimesArray.first?.workTimes.first
+        let lastTask = lastWorkTime == nil
+            ? nil
+            : Task(project: lastWorkTime?.project,
+                   body: lastWorkTime?.body ?? "",
+                   url: nil,
+                   day: dailyWorkTimesArray.first?.day,
+                   startAt: lastWorkTime?.startsAt,
+                   endAt: lastWorkTime?.endsAt)
+        coordinator.workTimesRequestedForNewWorkTimeView(sourceView: sourceView, lastTask: lastTask)
     }
     
     // MARK: - Private

--- a/TimeTable/Coordinators/TimeTable/WorkTime/WorkTimesCoordinator.swift
+++ b/TimeTable/Coordinators/TimeTable/WorkTime/WorkTimesCoordinator.swift
@@ -11,7 +11,7 @@ import UIKit
 typealias WorkTimesApiClient = (ApiClientProjectsType & ApiClientWorkTimesType & ApiClientUsersType & ApiClientMatchingFullTimeType)
 
 protocol WorkTimesCoordinatorDelegate: class {
-    func workTimesRequestedForNewWorkTimeView(sourceView: UIButton)
+    func workTimesRequestedForNewWorkTimeView(sourceView: UIButton, lastTask: Task?)
 }
 
 class WorkTimesCoordinator: BaseNavigationCoordinator, BaseTabBarCordninatorType {
@@ -60,9 +60,13 @@ class WorkTimesCoordinator: BaseNavigationCoordinator, BaseTabBarCordninatorType
 
 // MARK: - WorkTimesCoordinatorDelegate
 extension WorkTimesCoordinator: WorkTimesCoordinatorDelegate {
-    func workTimesRequestedForNewWorkTimeView(sourceView: UIButton) {
+    func workTimesRequestedForNewWorkTimeView(sourceView: UIButton, lastTask: Task?) {
         let controller: WorkTimeViewControlleralbe? = storyboardsManager.controller(storyboard: .workTime, controllerIdentifier: .initial)
-        let viewModel = WorkTimeViewModel(userInterface: controller, apiClient: apiClient, errorHandler: errorHandler, calendar: Calendar.autoupdatingCurrent)
+        let viewModel = WorkTimeViewModel(userInterface: controller,
+                                          apiClient: apiClient,
+                                          errorHandler: errorHandler,
+                                          calendar: Calendar.autoupdatingCurrent,
+                                          lastTask: lastTask)
         controller?.configure(viewModel: viewModel, notificationCenter: NotificationCenter.default)
         controller?.modalPresentationStyle = .popover
         controller?.preferredContentSize = CGSize(width: 300, height: 320)

--- a/TimeTable/Models/Errors/UIError.swift
+++ b/TimeTable/Models/Errors/UIError.swift
@@ -45,10 +45,14 @@ enum UIError: Error {
 extension UIError: Equatable {
     static func == (lhs: UIError, rhs: UIError) -> Bool {
         switch (lhs, rhs) {
+        case let (.cannotBeEmptyOr(lhsElement1, lhsElement2), .cannotBeEmptyOr(rhsElement1, rhsElement2)):
+            return [lhsElement1, lhsElement2].reduce(true, { $0 && [rhsElement1, rhsElement2].contains($1)})
         case (.cannotBeEmpty(let lhsElement), .cannotBeEmpty(let rhsElement)):
             return lhsElement == rhsElement
         case (.invalidFormat(let lhsElement), .invalidFormat(let rhsElement)):
             return lhsElement == rhsElement
+        case (.timeGreaterThan, .timeGreaterThan):
+            return true
         default:
             return false
         }

--- a/TimeTableTests/Coordinators/TimeTable/WorkTime/WorkTimesCoordinatorTests.swift
+++ b/TimeTableTests/Coordinators/TimeTable/WorkTime/WorkTimesCoordinatorTests.swift
@@ -49,21 +49,21 @@ class WorkTimesCoordinatorTests: XCTestCase {
     }
     
     // MARK: - WorkTimesCoordinatorDelegate
-    func testWorkTimesRequestedForNewWorkTimeViewWhileStoryboardsManagerReturendNil() {
+    func testWorkTimesRequestedForNewWorkTimeViewWhileStoryboardsManagerReturnedNil() {
         //Arrange
         let button = UIButton()
         //Act
-        workTimeCoordinator.workTimesRequestedForNewWorkTimeView(sourceView: button)
+        workTimeCoordinator.workTimesRequestedForNewWorkTimeView(sourceView: button, lastTask: nil)
         //Assert
         XCTAssertNil(workTimeCoordinator.root.children.last)
     }
     
-    func testWorkTimesRequestedForNewWorkTimeViewWhileStoryboardsManagerReturendInvalidController() {
+    func testWorkTimesRequestedForNewWorkTimeViewWhileStoryboardsManagerReturnedInvalidController() {
         //Arrange
         let button = UIButton()
         storyboardsManagerMock.workTimeController = UIViewController()
         //Act
-        workTimeCoordinator.workTimesRequestedForNewWorkTimeView(sourceView: button)
+        workTimeCoordinator.workTimesRequestedForNewWorkTimeView(sourceView: button, lastTask: nil)
         //Assert
         XCTAssertNil(workTimeCoordinator.root.children.last)
     }
@@ -73,7 +73,7 @@ class WorkTimesCoordinatorTests: XCTestCase {
         let button = UIButton()
         storyboardsManagerMock.workTimeController = WorkTimeController()
         //Act
-        workTimeCoordinator.workTimesRequestedForNewWorkTimeView(sourceView: button)
+        workTimeCoordinator.workTimesRequestedForNewWorkTimeView(sourceView: button, lastTask: nil)
         //Assert
         XCTAssertNil(workTimeCoordinator.root.children.last)
     }

--- a/TimeTableTests/Mocks/WorkTimeViewControllerMock.swift
+++ b/TimeTableTests/Mocks/WorkTimeViewControllerMock.swift
@@ -10,7 +10,9 @@ import Foundation
 @testable import TimeTable
 
 class WorkTimeViewControllerMock: WorkTimeViewControlleralbe {
+    // swiftlint:disable large_tuple
     private(set) var configureViewModelData: (called: Bool, viewModel: WorkTimeViewModelType?, notificationCenter: NotificationCenterType?) = (false, nil, nil)
+    // swiftlint:enable large_tuple
     private(set) var setUpCurrentProjectName: (currentProjectName: String?, allowsTask: Bool?) = (nil, nil)
     private(set) var dismissViewCalled = false
     private(set) var reloadProjectPickerCalled = false

--- a/TimeTableTests/Mocks/WorkTimesCoordinatorMock.swift
+++ b/TimeTableTests/Mocks/WorkTimesCoordinatorMock.swift
@@ -12,8 +12,10 @@ import XCTest
 class WorkTimesCoordinatorMock: WorkTimesCoordinatorDelegate {
     private(set) var requestedForNewWorkTimeViewCalled = false
     private(set) var requestedForNewWorkTimeViewSourceView: UIButton?
-    func workTimesRequestedForNewWorkTimeView(sourceView: UIButton) {
+    private(set) var requestedForNewWorkTimeViewLastTask: Task?
+    func workTimesRequestedForNewWorkTimeView(sourceView: UIButton, lastTask: Task?) {
         requestedForNewWorkTimeViewCalled = true
         requestedForNewWorkTimeViewSourceView = sourceView
+        requestedForNewWorkTimeViewLastTask = lastTask
     }
 }


### PR DESCRIPTION
If there is any task logged the same day, it will set automatically the start time of the new task to the end time of the last logged task.
It also sets end time to be not lower than start time and changes behaviour of setting time, while user is choosing project (change like normal proj -> full day proj -> again normal proj) and has already chosen time.